### PR TITLE
Fix small issues i can find

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -362,3 +362,6 @@ FodyWeavers.xsd
 ## CUSTOM
 .build/
 .dist/
+build/
+.idea/
+cmake-build*/

--- a/ff8_demaster.sln
+++ b/ff8_demaster.sln
@@ -7,6 +7,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ff8_demaster", "ff8_demaste
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "viiidem_customlauncher", "viiidem_customlauncher\viiidem_customlauncher.csproj", "{E8FE9475-BE92-4FCD-8DD2-782789A07CAC}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DE0EA73A-5BB5-429C-820F-5CFBB5610FF1}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x86 = Debug|x86

--- a/ff8_demaster/coreHeader.h
+++ b/ff8_demaster/coreHeader.h
@@ -68,6 +68,7 @@ extern int currentStage;
 extern FILE* logFile;
 void OutputDebug(const char* fmt, ...);
 
+void RenderTexture(bimg::ImageContainer* img);
 void RenderUncompressedTexture(bimg::ImageContainer* img, TextureFormatInfo& texInfo);
 void RenderCompressedTexture(bimg::ImageContainer* img, TextureFormatInfo& texInfo);
 

--- a/ff8_demaster/coreHeader.h
+++ b/ff8_demaster/coreHeader.h
@@ -28,7 +28,7 @@ extern const char* DIRECT_IO_EXPORT_DIR;
 extern DWORD DIRECT_IO_EXPORT_DIR_LEN;
 
 extern bx::DefaultAllocator texAllocator;
-bimg::ImageContainer* LoadImageFromFile(char* filename);
+bimg::ImageContainer* LoadImageFromFile(const char* const filename);
 
 void ApplyDirectIO();
 void ApplyUVPatch();
@@ -67,6 +67,7 @@ extern int currentStage;
 
 extern FILE* logFile;
 void OutputDebug(const char* fmt, ...);
+void DDSorPNG(char* buffer, size_t size, const char* fmt, ...);
 
 void RenderTexture(bimg::ImageContainer* img);
 void RenderUncompressedTexture(bimg::ImageContainer* img, TextureFormatInfo& texInfo);

--- a/ff8_demaster/coreHeader.h
+++ b/ff8_demaster/coreHeader.h
@@ -67,7 +67,7 @@ extern int currentStage;
 
 extern FILE* logFile;
 void OutputDebug(const char* fmt, ...);
-void DDSorPNG(char* buffer, size_t size, const char* fmt, ...);
+bool DDSorPNG(char* buffer, size_t size, const char* fmt, ...);
 
 void RenderTexture(bimg::ImageContainer* img);
 void RenderUncompressedTexture(bimg::ImageContainer* img, TextureFormatInfo& texInfo);

--- a/ff8_demaster/dllmain.cpp
+++ b/ff8_demaster/dllmain.cpp
@@ -305,6 +305,17 @@ bimg::ImageContainer* LoadImageFromFile(char* filename)
 
 	return img;
 }
+void RenderTexture(bimg::ImageContainer* img, TextureFormatInfo& texInfo)
+{
+	if (bimg::isCompressed(img->m_format))
+	{
+		RenderCompressedTexture(img, texInfo);
+	}
+	else
+	{
+		RenderUncompressedTexture(img, texInfo);
+	}
+}
 
 void RenderUncompressedTexture(bimg::ImageContainer* img, TextureFormatInfo& texInfo)
 {

--- a/ff8_demaster/dllmain.cpp
+++ b/ff8_demaster/dllmain.cpp
@@ -305,8 +305,9 @@ bimg::ImageContainer* LoadImageFromFile(char* filename)
 
 	return img;
 }
-void RenderTexture(bimg::ImageContainer* img, TextureFormatInfo& texInfo)
+void RenderTexture(bimg::ImageContainer* img)
 {
+	TextureFormatInfo& texInfo = s_textureFormat[img->m_format];
 	if (bimg::isCompressed(img->m_format))
 	{
 		RenderCompressedTexture(img, texInfo);

--- a/ff8_demaster/dllmain.cpp
+++ b/ff8_demaster/dllmain.cpp
@@ -255,7 +255,7 @@ LONG WINAPI ExceptionHandler(EXCEPTION_POINTERS* ep)
 	return EXCEPTION_CONTINUE_EXECUTION;
 }
 
-bimg::ImageContainer* LoadImageFromFile(char* filename)
+bimg::ImageContainer* LoadImageFromFile(const char* const filename)
 {
 	static bool glewLoaded = false;
 
@@ -304,6 +304,22 @@ bimg::ImageContainer* LoadImageFromFile(char* filename)
 	}
 
 	return img;
+}
+//appends DDS checks if file exists and then 
+void DDSorPNG(char* buffer, size_t in_size, const char* fmt, ...)
+{
+	const size_t size = in_size - 4U; //for extension
+	va_list args;
+	va_start(args,fmt);
+	vsnprintf(buffer, size, fmt, args);
+	strcat(buffer, ".dds");
+	if (GetFileAttributesA(buffer) == INVALID_FILE_ATTRIBUTES)
+	{
+		vsnprintf(buffer, size, fmt, args);
+		strcat(buffer,".png");
+	}
+	va_end(args);
+
 }
 void RenderTexture(bimg::ImageContainer* img)
 {

--- a/ff8_demaster/dllmain.cpp
+++ b/ff8_demaster/dllmain.cpp
@@ -305,21 +305,24 @@ bimg::ImageContainer* LoadImageFromFile(const char* const filename)
 
 	return img;
 }
-//appends DDS checks if file exists and then 
-void DDSorPNG(char* buffer, size_t in_size, const char* fmt, ...)
+//appends DDS checks if file exists and then returns false if atleast one exists.
+bool DDSorPNG(char* buffer, size_t in_size, const char* fmt, ...)
 {
 	const size_t size = in_size - 4U; //for extension
 	va_list args;
-	va_start(args,fmt);
+	va_start(args, fmt);
 	vsnprintf(buffer, size, fmt, args);
 	strcat(buffer, ".dds");
+	va_end(args);
 	if (GetFileAttributesA(buffer) == INVALID_FILE_ATTRIBUTES)
 	{
+		va_start(args, fmt);
 		vsnprintf(buffer, size, fmt, args);
 		strcat(buffer,".png");
+		va_end(args);
+		return GetFileAttributesA(buffer) == INVALID_FILE_ATTRIBUTES;
 	}
-	va_end(args);
-
+	return false;
 }
 void RenderTexture(bimg::ImageContainer* img)
 {

--- a/ff8_demaster/dllmain.cpp
+++ b/ff8_demaster/dllmain.cpp
@@ -86,7 +86,6 @@ void DEB_JMP(char* c, DWORD a, DWORD b, DWORD cc, DWORD d, DWORD e)
 	sprintf(localD, "Wrong address at: %08x\n", (unsigned int)c);
 	if (IsBadReadPtr(c, 4)) 
 	{
-		//OutputDebugStringA(localD);
 		__asm
 		{
 			//INT 3

--- a/ff8_demaster/dllmain.cpp
+++ b/ff8_demaster/dllmain.cpp
@@ -305,7 +305,7 @@ bimg::ImageContainer* LoadImageFromFile(const char* const filename)
 
 	return img;
 }
-//appends DDS checks if file exists and then returns false if atleast one exists.
+//appends DDS checks if file exists and then checks for PNG. returns false if atleast one exists. true on failure.
 bool DDSorPNG(char* buffer, size_t in_size, const char* fmt, ...)
 {
 	const size_t size = in_size - 4U; //for extension

--- a/ff8_demaster/dllmain.cpp
+++ b/ff8_demaster/dllmain.cpp
@@ -269,14 +269,14 @@ bimg::ImageContainer* LoadImageFromFile(char* filename)
 		if (GLEW_OK != err)
 		{
 			/* Problem: glewInit failed, something is seriously wrong. */
-			OutputDebug("GLEW Error: %s\n", glewGetErrorString(err));
+			OutputDebug("%s - GLEW Error: %s\n", __func__, glewGetErrorString(err));
 		}
 	}
 
 	bimg::ImageContainer* img = nullptr;
 	char msg[1024]{ 0 };
 
-	OutputDebug("Opening file: %s\n", filename);
+	OutputDebug("%s - Opening File: %s\n", __func__, filename);
 
 	FILE* file = fopen(filename, "rb");
 
@@ -290,7 +290,7 @@ bimg::ImageContainer* LoadImageFromFile(char* filename)
 
 		buffer = (char*)malloc(filesize + 1);
 		fseek(file, 0, SEEK_SET);
-		fread(buffer, filesize, 1, file);
+		(void)fread(buffer, filesize, 1, file);
 
 		fclose(file);
 
@@ -363,8 +363,8 @@ BOOL WINAPI DllMain(
 	SetUnhandledExceptionFilter(ExceptionHandler);
 
 	AllocConsole();
-	freopen("CONOUT$", "w", stdout);
-	freopen("CON", "r", stdin);
+	(void)freopen("CONOUT$", "w", stdout);
+	(void)freopen("CON", "r", stdin);
 	InitTest();
 	ReadConfigFile();
 	if (LOG) logFile = fopen("demasterlog.txt", "wb");

--- a/ff8_demaster/ff8_demaster.vcxproj
+++ b/ff8_demaster/ff8_demaster.vcxproj
@@ -33,7 +33,7 @@
     <LinkIncremental>true</LinkIncremental>
     <IncludePath>vendor\include\;vendor\include\compat\msvc;$(IncludePath)</IncludePath>
     <LibraryPath>vendor\lib\;vendor\lib\bgfx;$(LibraryPath)</LibraryPath>
-    <OutDir>C:\Program Files (x86)\Steam\steamapps\common\FINAL FANTASY VIII Remastered\</OutDir>
+    <OutDir>$(SolutionDir).dist\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir).build\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/ff8_demaster/ff8_demaster.vcxproj
+++ b/ff8_demaster/ff8_demaster.vcxproj
@@ -33,8 +33,8 @@
     <LinkIncremental>true</LinkIncremental>
     <IncludePath>vendor\include\;vendor\include\compat\msvc;$(IncludePath)</IncludePath>
     <LibraryPath>vendor\lib\;vendor\lib\bgfx;$(LibraryPath)</LibraryPath>
-    <OutDir>$(SolutionDir)\.dist\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)\.build\$(Configuration)\</IntDir>
+    <OutDir>C:\Program Files (x86)\Steam\steamapps\common\FINAL FANTASY VIII Remastered\</OutDir>
+    <IntDir>$(SolutionDir).build\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -57,6 +57,7 @@
       <AdditionalDependencies>StackWalker.lib;glew32s.lib;opengl32.lib;psapi.lib;bxDebug.lib;bimgDebug.lib;bimg_decodeDebug.lib;bimg_encodeDebug.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>MSVCRT;MSVCRTD;LIBCMT;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <ForceFileOutput>MultiplyDefinedSymbolOnly</ForceFileOutput>
+      <AdditionalOptions>/IGNORE:4075,4099 %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <PostBuildEvent>
       <Command>del $(SolutionDir).dist\$(Configuration)\$(AssemblyName).exp

--- a/ff8_demaster/iopatch.cpp
+++ b/ff8_demaster/iopatch.cpp
@@ -38,9 +38,7 @@ __declspec(naked) void directIO_fopenReroute()
 	if (GetFileAttributesA(IO_backlogFilePath) == INVALID_FILE_ATTRIBUTES)
 	{
 		OutputDebug("%s: %s, %s\n", __func__, IO_backlogFilePath, "file not found");
-		sprintf(IO_backlogFilePath, "%stextures\\null.dds", DIRECT_IO_EXPORT_DIR);
-		if (GetFileAttributesA(IO_backlogFilePath) == INVALID_FILE_ATTRIBUTES)
-			sprintf(IO_backlogFilePath, "%stextures\\null.png", DIRECT_IO_EXPORT_DIR);
+		DDSorPNG(IO_backlogFilePath,256U, "%stextures\\null", DIRECT_IO_EXPORT_DIR);
 	}
 	else
 	{

--- a/ff8_demaster/iopatch.cpp
+++ b/ff8_demaster/iopatch.cpp
@@ -37,12 +37,15 @@ __declspec(naked) void directIO_fopenReroute()
 
 	if (GetFileAttributesA(IO_backlogFilePath) == INVALID_FILE_ATTRIBUTES)
 	{
+		OutputDebug("%s: %s, %s\n", __func__, IO_backlogFilePath, "file not found");
 		sprintf(IO_backlogFilePath, "%stextures\\null.dds", DIRECT_IO_EXPORT_DIR);
 		if (GetFileAttributesA(IO_backlogFilePath) == INVALID_FILE_ATTRIBUTES)
 			sprintf(IO_backlogFilePath, "%stextures\\null.png", DIRECT_IO_EXPORT_DIR);
 	}
-
-	OutputDebug("%s: %s\n", __func__, IO_backlogFilePath);
+	else
+	{
+		OutputDebug("%s: %s\n", __func__, IO_backlogFilePath);
+	}
 
 	__asm
 	{

--- a/ff8_demaster/texturepatch_v2.cpp
+++ b/ff8_demaster/texturepatch_v2.cpp
@@ -81,7 +81,7 @@ void _cltVoid()
 		return;
 	if (textureType == 57) //field
 		return;
-	OutputDebug("\ncommon_load_texture: tex_type: %s, pal: %d, unk: %08x, bHaveHD: %s, Tpage: %d\n", GetTextureType(textureType), palette, unknownDword, bHaveHD > 0 ? "TRUE" : "FALSE", tPage-16);
+	OutputDebug("\ncommon_load_texture: tex_type: %s, pal: %d, unk: %08x, bHaveHD: %s, Tpage: %d\n", GetTextureType(textureType), palette, unknownDword, bHaveHD > 0 ? "TRUE" : "FALSE", tPage);
 
 	return;
 }

--- a/ff8_demaster/texturepatch_v2.cpp
+++ b/ff8_demaster/texturepatch_v2.cpp
@@ -81,7 +81,7 @@ void _cltVoid()
 		return;
 	if (textureType == 57) //field
 		return;
-	OutputDebug("common_load_texture: tex_type: %s, pal: %d, unk: %08x, bHaveHD: %s, Tpage: %d\n", GetTextureType(textureType), palette, unknownDword, bHaveHD > 0 ? "TRUE" : "FALSE", tPage);
+	OutputDebug("\ncommon_load_texture: tex_type: %s, pal: %d, unk: %08x, bHaveHD: %s, Tpage: %d\n", GetTextureType(textureType), palette, unknownDword, bHaveHD > 0 ? "TRUE" : "FALSE", tPage-16);
 
 	return;
 }

--- a/ff8_demaster/texturepatch_v2_battleCharacter.cpp
+++ b/ff8_demaster/texturepatch_v2_battleCharacter.cpp
@@ -14,10 +14,8 @@ void _bcpObtainTextureDatas(int aIndex)
 {
 	char n[256]{ 0 };
 
-	sprintf(n, "%stextures\\battle.fs\\hd_new\\d%xc%03u_0.dds", DIRECT_IO_EXPORT_DIR, (aIndex - 4097) / 100, (aIndex - 4097) % 100);
-	if (GetFileAttributesA(n) == INVALID_FILE_ATTRIBUTES)
-		sprintf(n, "%stextures\\battle.fs\\hd_new\\d%xc%03u_0.png", DIRECT_IO_EXPORT_DIR, (aIndex - 4097) / 100, (aIndex - 4097) % 100);
-
+	DDSorPNG(n, 256, "%stextures\\battle.fs\\hd_new\\d%xc%03u_0", DIRECT_IO_EXPORT_DIR, (aIndex - 4097) / 100, (aIndex - 4097) % 100);
+	
 	bimg::ImageContainer* img = LoadImageFromFile(n); //chara 0
 	width_bcp = img->m_width * 2;
 	height_bcp = img->m_height * 2;

--- a/ff8_demaster/texturepatch_v2_battleHooks.cpp
+++ b/ff8_demaster/texturepatch_v2_battleHooks.cpp
@@ -19,9 +19,7 @@ DWORD _bhpMonsterStructVoid()
 	if (batId < 0 || batId>144)
 		return -1;
 	char localn[256]{ 0 };
-	sprintf(localn, "%stextures\\battle.fs\\hd_new\\c0m%03d_0.dds", DIRECT_IO_EXPORT_DIR, batId);
-	if (GetFileAttributesA(localn) == INVALID_FILE_ATTRIBUTES)
-		sprintf(localn, "%stextures\\battle.fs\\hd_new\\c0m%03d_0.png", DIRECT_IO_EXPORT_DIR, batId);
+	DDSorPNG(localn, 256, "%stextures\\battle.fs\\hd_new\\c0m%03d_0", DIRECT_IO_EXPORT_DIR, batId);
 	int maxPal = 0;
 	int _strlen = strlen(localn);
 	while (1)
@@ -99,9 +97,7 @@ BYTE _bhpVoid()
 		monsId[3] = '\0';
 		int intMonsId = atoi(monsId);
 
-		sprintf(localPath, "%stextures\\battle.fs\\hd_new\\c0m%03d_0.dds", DIRECT_IO_EXPORT_DIR, intMonsId);
-		if (GetFileAttributesA(localPath) == INVALID_FILE_ATTRIBUTES)
-			sprintf(localPath, "%stextures\\battle.fs\\hd_new\\c0m%03d_0.png", DIRECT_IO_EXPORT_DIR, intMonsId);
+		DDSorPNG(localPath, 256, "%stextures\\battle.fs\\hd_new\\c0m%03d_0", DIRECT_IO_EXPORT_DIR, intMonsId);
 		if (GetFileAttributesA(localPath) == INVALID_FILE_ATTRIBUTES) //file doesn't exist, so please do not replace textures
 			return 0;
 

--- a/ff8_demaster/texturepatch_v2_battleScenery.cpp
+++ b/ff8_demaster/texturepatch_v2_battleScenery.cpp
@@ -48,9 +48,7 @@ void _bspGl()
 
 	OutputDebug("_bspGl()::Stage: %d, Tpage: %d, Palette: %d\n", currentStage, tPage, palette);
 
-	sprintf(localn, "%stextures\\battle.fs\\hd_new\\a0stg%03d_%d.dds", DIRECT_IO_EXPORT_DIR, currentStage, tPage);
-	if (GetFileAttributesA(localn) == INVALID_FILE_ATTRIBUTES)
-		sprintf(localn, "%stextures\\battle.fs\\hd_new\\a0stg%03d_%d.png", DIRECT_IO_EXPORT_DIR, currentStage, tPage);
+	DDSorPNG(localn,256, "%stextures\\battle.fs\\hd_new\\a0stg%03d_%d", DIRECT_IO_EXPORT_DIR, currentStage, tPage);
 
 	if (bss[tPage - 16].buffer == NULL) //texture never loaded
 	{
@@ -97,11 +95,7 @@ void _bspGl()
 			//OutputDebug("\tstbi::w: %d; h: %d; channels: %d\n", bss[tPage - 16].width, bss[tPage - 16].height, bss[tPage - 16].channels);
 		}
 	}
-	TextureFormatInfo& texInfo = s_textureFormat[bss[tPage - 16].buffer->m_format];
-	if (bimg::isCompressed(bss[tPage - 16].buffer->m_format))
-		RenderCompressedTexture(bss[tPage - 16].buffer, texInfo);
-	else
-		RenderUncompressedTexture(bss[tPage - 16].buffer, texInfo);
+	RenderTexture(bss[tPage - 16].buffer);
 	//we no longer free the buffer here
 	return;
 }
@@ -125,9 +119,7 @@ DWORD _bspCheck()
 	if (tPage > 21)
 		return 0;
 	char localn[256]{ 0 };
-	sprintf(localn, "%stextures\\battle.fs\\hd_new\\a0stg%03d_%d.dds", DIRECT_IO_EXPORT_DIR, currentStage, tPage);
-	if (GetFileAttributesA(localn) == INVALID_FILE_ATTRIBUTES)
-		sprintf(localn, "%stextures\\battle.fs\\hd_new\\a0stg%03d_%d.png", DIRECT_IO_EXPORT_DIR, currentStage, tPage);
+	DDSorPNG(localn,256, "%stextures\\battle.fs\\hd_new\\a0stg%03d_%d", DIRECT_IO_EXPORT_DIR, currentStage, tPage);
 	if (GetFileAttributesA(localn) == INVALID_FILE_ATTRIBUTES)
 	{
 		OutputDebug("_bspCheck FAILED ON TEXTURE!; Expected: a0stg%03d_%d.(dds|png)\n", currentStage, tPage);

--- a/ff8_demaster/texturepatch_v2_fieldBackground.cpp
+++ b/ff8_demaster/texturepatch_v2_fieldBackground.cpp
@@ -50,11 +50,11 @@ char* _fbgHdInjectVoid()
 
 	GetFieldBackgroundFile(n);
 	
-	sprintf(localn, "%stextures\\%s%u_%u.dds", DIRECT_IO_EXPORT_DIR, n, fbpRequestedTpage-16, palette/2);
-	sprintf(localn2, "%s%u_%u", n, fbpRequestedTpage - 16, palette/2);
+	sprintf(localn, "%stextures\\%s%u_%u.dds", DIRECT_IO_EXPORT_DIR, n, fbpRequestedTpage-16, palette);
+	sprintf(localn2, "%s%u_%u", n, fbpRequestedTpage - 16, palette);
 	if (GetFileAttributesA(localn) == INVALID_FILE_ATTRIBUTES)
 	{
-		sprintf(localn, "%stextures\\%s%u_%u.png", DIRECT_IO_EXPORT_DIR, n, fbpRequestedTpage - 16, palette/2);
+		sprintf(localn, "%stextures\\%s%u_%u.png", DIRECT_IO_EXPORT_DIR, n, fbpRequestedTpage - 16, palette);
 	}
 	if (GetFileAttributesA(localn) == INVALID_FILE_ATTRIBUTES)
 	{

--- a/ff8_demaster/texturepatch_v2_fieldBackground.cpp
+++ b/ff8_demaster/texturepatch_v2_fieldBackground.cpp
@@ -42,8 +42,8 @@ DWORD fbpRequestedTpage;
 char* _fbgHdInjectVoid()
 {
 	//directIO_fopenReroute: DEMASTER_EXP\textures\DEMASTER_EXP\textures\field_bg\bv\bvtr_1\bvtr_1_0_2.png, file not found
-	static char n[256]{ 0 };
-	char n2[256]{ 0 };
+	char n[256]{ 0 };
+	static char n2[256]{ 0 };
 	char localn[256]{ 0 };
 	static char localn2[256]{ 0 };
 	int palette = tex_header[52];

--- a/ff8_demaster/texturepatch_v2_fieldBackground.cpp
+++ b/ff8_demaster/texturepatch_v2_fieldBackground.cpp
@@ -41,25 +41,34 @@ DWORD fbpRequestedTpage;
 
 char* _fbgHdInjectVoid()
 {
+	//directIO_fopenReroute: DEMASTER_EXP\textures\DEMASTER_EXP\textures\field_bg\bv\bvtr_1\bvtr_1_0_2.png, file not found
 	static char n[256]{ 0 };
-	static char localn[256]{ 0 };
+	char n2[256]{ 0 };
+	char localn[256]{ 0 };
+	static char localn2[256]{ 0 };
 	int palette = tex_header[52];
 
 	GetFieldBackgroundFile(n);
 	
-	sprintf(localn, "%stextures\\%s%u_%u.dds", DIRECT_IO_EXPORT_DIR, n, fbpRequestedTpage-16, palette);
-	if (GetFileAttributesA(localn) == INVALID_FILE_ATTRIBUTES)
-		sprintf(localn, "%stextures\\%s%u_%u.png", DIRECT_IO_EXPORT_DIR, n, fbpRequestedTpage - 16, palette);
-
-	OutputDebug("%s: %s\n", __func__, localn);
-	
+	sprintf(localn, "%stextures\\%s%u_%u.dds", DIRECT_IO_EXPORT_DIR, n, fbpRequestedTpage-16, palette/2);
+	sprintf(localn2, "%s%u_%u", n, fbpRequestedTpage - 16, palette/2);
 	if (GetFileAttributesA(localn) == INVALID_FILE_ATTRIBUTES)
 	{
-		strcat(n, "%u");
-		return n;
+		sprintf(localn, "%stextures\\%s%u_%u.png", DIRECT_IO_EXPORT_DIR, n, fbpRequestedTpage - 16, palette/2);
 	}
-	
-	return localn;
+	if (GetFileAttributesA(localn) == INVALID_FILE_ATTRIBUTES)
+	{
+		OutputDebug("%s: %s, %s\n", __func__, localn, "palette not found");
+		strcat(n, "%u");
+		sprintf(n2, n, fbpRequestedTpage - 16);
+		OutputDebug("%s: %s\n", __func__, n2);
+		return n2;
+	}
+	else
+	{
+		OutputDebug("%s: %s\n", __func__, localn);
+		return localn2;
+	}
 }
 
 __declspec(naked) void _fbgHdInject()
@@ -98,12 +107,20 @@ DWORD _fbgCheckHdAvailableVoid()
 	GetFieldBackgroundFile(n);
 	
 	sprintf(localn, "%stextures\\%s0.dds", DIRECT_IO_EXPORT_DIR, n);
+	
 
 	if (GetFileAttributesA(localn) == INVALID_FILE_ATTRIBUTES)
+	{
+		OutputDebug("%s: %s, %s\n", __func__, localn, "not found");
 		sprintf(localn, "%stextures\\%s0.png", DIRECT_IO_EXPORT_DIR, n);
+	}
+
 
 	if (GetFileAttributesA(localn) == INVALID_FILE_ATTRIBUTES)
+	{
+		OutputDebug("%s: %s, %s\n", __func__, localn, "not found");
 		return 0;
+	}
 
 	OutputDebug("%s: %s\n", __func__, localn);
 	

--- a/ff8_demaster/texturepatch_v2_fieldBackground.cpp
+++ b/ff8_demaster/texturepatch_v2_fieldBackground.cpp
@@ -61,15 +61,15 @@ char* GetFieldBackgroundReplacementTextureName()
 	static char localn2[256]{ 0 };
 	int palette = tex_header[52];
 
-	GetFieldBackgroundFile(n);
+	GetFieldBackgroundFilename(n);
 
-	sprintf(localn2, "%s%u_%u", n, fbpRequestedTpage - 16, palette);
-	DDSorPNG(localn,256, "%stextures\\%s%u_%u", DIRECT_IO_EXPORT_DIR, n, fbpRequestedTpage-16, palette);
+	sprintf(localn2, "%s%u_%u", n, fieldBackgroundRequestedTPage - 16, palette);
+	DDSorPNG(localn,256, "%stextures\\%s%u_%u", DIRECT_IO_EXPORT_DIR, n, fieldBackgroundRequestedTPage -16, palette);
 
 	if (GetFileAttributesA(localn) == INVALID_FILE_ATTRIBUTES)
 	{
 		OutputDebug("%s: %s, %s\n", __func__, localn, "palette not found");
-		sprintf(n2, "%s%u",n, fbpRequestedTpage - 16);
+		sprintf(n2, "%s%u",n, fieldBackgroundRequestedTPage - 16);
 		OutputDebug("%s: %s\n", __func__, n2);
 		return n2;
 	}

--- a/ff8_demaster/texturepatch_v2_fieldBackground.cpp
+++ b/ff8_demaster/texturepatch_v2_fieldBackground.cpp
@@ -49,18 +49,14 @@ char* _fbgHdInjectVoid()
 	int palette = tex_header[52];
 
 	GetFieldBackgroundFile(n);
-	
-	sprintf(localn, "%stextures\\%s%u_%u.dds", DIRECT_IO_EXPORT_DIR, n, fbpRequestedTpage-16, palette);
+
 	sprintf(localn2, "%s%u_%u", n, fbpRequestedTpage - 16, palette);
-	if (GetFileAttributesA(localn) == INVALID_FILE_ATTRIBUTES)
-	{
-		sprintf(localn, "%stextures\\%s%u_%u.png", DIRECT_IO_EXPORT_DIR, n, fbpRequestedTpage - 16, palette);
-	}
+	DDSorPNG(localn,256, "%stextures\\%s%u_%u", DIRECT_IO_EXPORT_DIR, n, fbpRequestedTpage-16, palette);
+
 	if (GetFileAttributesA(localn) == INVALID_FILE_ATTRIBUTES)
 	{
 		OutputDebug("%s: %s, %s\n", __func__, localn, "palette not found");
-		strcat(n, "%u");
-		sprintf(n2, n, fbpRequestedTpage - 16);
+		sprintf(n2, "%s%u",n, fbpRequestedTpage - 16);
 		OutputDebug("%s: %s\n", __func__, n2);
 		return n2;
 	}
@@ -101,20 +97,12 @@ __declspec(naked) void _fbgHdInject()
 //it to individually control fields- pretty cool
 DWORD _fbgCheckHdAvailableVoid()
 {
-	char n[256]{ 0 };
-	char localn[256]{ 0 };
+	const size_t s = 256U;
+	char n[s]{ 0 };
+	char localn[s]{ 0 };
 
 	GetFieldBackgroundFile(n);
-	
-	sprintf(localn, "%stextures\\%s0.dds", DIRECT_IO_EXPORT_DIR, n);
-	
-
-	if (GetFileAttributesA(localn) == INVALID_FILE_ATTRIBUTES)
-	{
-		OutputDebug("%s: %s, %s\n", __func__, localn, "not found");
-		sprintf(localn, "%stextures\\%s0.png", DIRECT_IO_EXPORT_DIR, n);
-	}
-
+	DDSorPNG(localn, s, "%stextures\\%s0", DIRECT_IO_EXPORT_DIR, n);
 
 	if (GetFileAttributesA(localn) == INVALID_FILE_ATTRIBUTES)
 	{

--- a/ff8_demaster/texturepatch_v2_fieldChara.cpp
+++ b/ff8_demaster/texturepatch_v2_fieldChara.cpp
@@ -31,23 +31,17 @@ void _fcpObtainTextureDatas(int bIndex, int aIndex)
 	BOOL bNonHdParent = FALSE;
 
 	char testPath[256]{ 0 };
-	sprintf(testPath, "%s%s.dds", texPath, tempSprint);
-	if (GetFileAttributesA(testPath) == INVALID_FILE_ATTRIBUTES)
-		sprintf(testPath, "%s%s.png", texPath, tempSprint);
+	DDSorPNG(testPath,256, "%s%s", texPath, tempSprint);
 	if (GetFileAttributesA(testPath) == INVALID_FILE_ATTRIBUTES)
 	{
-		sprintf(testPath, "%s_new%s.dds", texPath, tempSprint);
-		if (GetFileAttributesA(testPath) == INVALID_FILE_ATTRIBUTES)
-			sprintf(testPath, "%s_new%s.png", texPath, tempSprint);
+		DDSorPNG(testPath, 256,"%s_new%s", texPath, tempSprint);
 	}
 	else
 		bNonHdParent = TRUE;
 
 	if (GetFileAttributesA(testPath) == INVALID_FILE_ATTRIBUTES)
 	{
-		sprintf(testPath, "%s_new\\d000_0.dds", tempPath); //ERROR !!!!
-		if (GetFileAttributesA(testPath) == INVALID_FILE_ATTRIBUTES)
-			sprintf(testPath, "%s_new\\d000_0.png", tempPath); //ERROR !!!!
+		DDSorPNG(testPath,256, "%s_new\\d000_0", tempPath); //ERROR !!!!
 	}
 
 	strcpy(texPath, testPath); //establish path

--- a/ff8_demaster/texturepatch_v2_fieldChara.cpp
+++ b/ff8_demaster/texturepatch_v2_fieldChara.cpp
@@ -57,7 +57,6 @@ void _fcpObtainTextureDatas(int bIndex, int aIndex)
 
 	//the most important is height here
 	height_fcp = img->m_height * 2;
-	int scale = img->m_height / 384; //normally should be always 1
 	
 
 

--- a/ff8_demaster/texturepatch_v2_fieldChara.cpp
+++ b/ff8_demaster/texturepatch_v2_fieldChara.cpp
@@ -60,8 +60,8 @@ void _fcpObtainTextureDatas(int bIndex, int aIndex)
 	
 
 
+	OutputDebug("_fcpObtainTextureDatas:: width=%d, height=%d, width_fcp=%d, height_fcp=%d, filename=%s\n", img->m_width, img->m_height, width_fcp, height_fcp, texPath);
 	bimg::imageFree(img);
-	OutputDebug("_fcpObtainTextureDatas:: width=%d, height=%d, filename=%s\n", width_fcp, height_fcp, texPath);
 	return;
 }
 

--- a/ff8_demaster/texturepatch_v2_world.cpp
+++ b/ff8_demaster/texturepatch_v2_world.cpp
@@ -59,7 +59,8 @@ void _wtpGl()
 
 	DWORD unk = *(DWORD*)(IMAGE_BASE + 0x17424B4);
 	int texIndex = lastKnownTextureId;
-	OutputDebug("_wtpGl()::localEAX: %d, Tpage: %d, Palette: %d, TexIndex: %d\n", *(DWORD*)(IMAGE_BASE + 0x1780f88), tPage, palette, texIndex);
+	if(!(tPage == 29 && (palette == 0 || palette==2)))
+		OutputDebug("_wtpGl()::localEAX: %d, Tpage: %d, Palette: %d, TexIndex: %d\n", *(DWORD*)(IMAGE_BASE + 0x1780f88), tPage, palette, texIndex);
 
 	int getTexIndex = GetTextureIndex();
 	if (getTexIndex < 20 && (tPage > 14 && tPage < 26))
@@ -118,7 +119,7 @@ void _wtpGl()
 			ws[wmStructPointer].width = img->m_width;
 			ws[wmStructPointer].bActive = true;
 
-			OutputDebug("\tstbi::w: %d; h: %d; channels: %d; path: %s\n", ws[wmStructPointer].width, ws[wmStructPointer].height, ws[wmStructPointer].channels, localn);
+			OutputDebug("\tstbi::w: %d; h: %d; channels: %d\n", ws[wmStructPointer].width, ws[wmStructPointer].height, ws[wmStructPointer].channels);
 		}
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/ff8_demaster/texturepatch_v2_world.cpp
+++ b/ff8_demaster/texturepatch_v2_world.cpp
@@ -50,7 +50,7 @@ int GetTextureIndex();
 //you can't just create new folder because >WEEP< - too lazy to find the cause
 
 DWORD lastKnownTextureId;
-
+#define DEBUG_LINE OutputDebug("%u, %s\n",__LINE__,__func__)
 void _wtpGl()
 {
 	DWORD tPage = gl_textures[50];
@@ -92,7 +92,9 @@ void _wtpGl()
 	{
 		sprintf(localn, "%stextures\\world\\dat\\wmset\\wmset_%03d_0.dds", DIRECT_IO_EXPORT_DIR, getTexIndex);
 		if (GetFileAttributesA(localn) == INVALID_FILE_ATTRIBUTES)
+		{
 			sprintf(localn, "%stextures\\world\\dat\\wmset\\wmset_%03d_0.png", DIRECT_IO_EXPORT_DIR, getTexIndex);
+		}
 		int wmStructPointer = -1;
 		switch (getTexIndex)
 		{
@@ -109,7 +111,7 @@ void _wtpGl()
 			wmStructPointer = 21;
 			break;
 		}
-
+		DEBUG_LINE;
 		if (!ws[wmStructPointer].bActive)
 		{
 			bimg::ImageContainer* img = LoadImageFromFile(localn);
@@ -118,17 +120,26 @@ void _wtpGl()
 			ws[wmStructPointer].height = img->m_height;
 			ws[wmStructPointer].width = img->m_width;
 			ws[wmStructPointer].bActive = true;
-
+			DEBUG_LINE;
 			OutputDebug("\tstbi::w: %d; h: %d; channels: %d\n", ws[wmStructPointer].width, ws[wmStructPointer].height, ws[wmStructPointer].channels);
 		}
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
-		TextureFormatInfo& texInfo = s_textureFormat[ws[texIndex].buffer->m_format];
-		if (bimg::isCompressed(ws[texIndex].buffer->m_format))
-			RenderCompressedTexture(ws[texIndex].buffer, texInfo);
+		DEBUG_LINE;
+		OutputDebug("\t%u\n", texIndex);
+		TextureFormatInfo& texInfo = s_textureFormat[ws[wmStructPointer].buffer->m_format];
+		DEBUG_LINE;
+		if (bimg::isCompressed(ws[wmStructPointer].buffer->m_format))
+		{
+			DEBUG_LINE;
+			RenderCompressedTexture(ws[wmStructPointer].buffer, texInfo);
+		}
 		else
-			RenderUncompressedTexture(ws[texIndex].buffer, texInfo);
+		{
+			DEBUG_LINE;
+			RenderUncompressedTexture(ws[wmStructPointer].buffer, texInfo);
+		}
 	}
 	return;
 }

--- a/ff8_demaster/texturepatch_v2_world.cpp
+++ b/ff8_demaster/texturepatch_v2_world.cpp
@@ -59,8 +59,8 @@ void _wtpGl()
 
 	DWORD unk = *(DWORD*)(IMAGE_BASE + 0x17424B4);
 	int texIndex = lastKnownTextureId;
-	sprintf(localn, "_wtpGl()::localEAX: %d, Tpage: %d, Palette: %d, TexIndex: %d\n", *(DWORD*)(IMAGE_BASE + 0x1780f88), tPage, palette, texIndex);
-	OutputDebugStringA(localn);
+	OutputDebug("_wtpGl()::localEAX: %d, Tpage: %d, Palette: %d, TexIndex: %d\n", *(DWORD*)(IMAGE_BASE + 0x1780f88), tPage, palette, texIndex);
+
 	int getTexIndex = GetTextureIndex();
 	if (getTexIndex < 20 && (tPage > 14 && tPage < 26))
 	{
@@ -76,8 +76,7 @@ void _wtpGl()
 			strcpy(ws[texIndex].localPath, localn);
 			ws[texIndex].buffer = img;
 			ws[texIndex].bActive = TRUE;
-			sprintf(localn, "\tstbi::w: %d; h: %d; channels: %d\n", ws[texIndex].width, ws[texIndex].height, ws[texIndex].channels);
-			OutputDebugStringA(localn);
+			OutputDebug("\tstbi::w: %d; h: %d; channels: %d\n", ws[texIndex].width, ws[texIndex].height, ws[texIndex].channels);
 		}
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -118,8 +117,8 @@ void _wtpGl()
 			ws[wmStructPointer].height = img->m_height;
 			ws[wmStructPointer].width = img->m_width;
 			ws[wmStructPointer].bActive = true;
-			sprintf(localn, "\tstbi::w: %d; h: %d; channels: %d\n", ws[wmStructPointer].width, ws[wmStructPointer].height, ws[wmStructPointer].channels);
-			OutputDebugStringA(localn);
+
+			OutputDebug("\tstbi::w: %d; h: %d; channels: %d; path: %s\n", ws[wmStructPointer].width, ws[wmStructPointer].height, ws[wmStructPointer].channels, localn);
 		}
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/ff8_demaster/texturepatch_v2_world.cpp
+++ b/ff8_demaster/texturepatch_v2_world.cpp
@@ -50,7 +50,7 @@ int GetTextureIndex();
 //you can't just create new folder because >WEEP< - too lazy to find the cause
 
 DWORD lastKnownTextureId;
-void LoadImageIntoStruct(size_t texIndex, const char *const localn)
+void LoadImageIntoWorldStruct(size_t texIndex, const char *const localn)
 {
 	if (ws[texIndex].bActive == FALSE || ws[texIndex].buffer == NULL)
 	{
@@ -79,7 +79,7 @@ void _wtpGl()
 	if (getTexIndex < 20 && (tPage > 14 && tPage < 26))
 	{
 		DDSorPNG(localn, 256,"%stextures\\world\\dat\\texl\\texl_%03d_0", DIRECT_IO_EXPORT_DIR, /*tPage*/texIndex);
-		LoadImageIntoStruct(texIndex, localn);
+		LoadImageIntoWorldStruct(texIndex, localn);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);		
 		RenderTexture(ws[texIndex].buffer);
@@ -100,7 +100,7 @@ void _wtpGl()
 			wmStructPointer = 21;
 			break;
 		}
-		LoadImageIntoStruct(wmStructPointer, localn);
+		LoadImageIntoWorldStruct(wmStructPointer, localn);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 		RenderTexture(ws[wmStructPointer].buffer);
@@ -179,7 +179,7 @@ DWORD _wtpCheck()
 	}
 	if (GetFileAttributesA(localn) == INVALID_FILE_ATTRIBUTES)
 	{
-		OutputDebug("%s: %s, Failed to load!", __func__, localn);
+		//OutputDebug("%s: %s, Failed to load!\n", __func__, localn); //spamming message!
 		return 0;
 	}
 	

--- a/ff8_demaster/texturepatch_v2_world.cpp
+++ b/ff8_demaster/texturepatch_v2_world.cpp
@@ -50,7 +50,6 @@ int GetTextureIndex();
 //you can't just create new folder because >WEEP< - too lazy to find the cause
 
 DWORD lastKnownTextureId;
-#define DEBUG_LINE OutputDebug("%u, %s\n",__LINE__,__func__)
 void _wtpGl()
 {
 	DWORD tPage = gl_textures[50];
@@ -111,7 +110,6 @@ void _wtpGl()
 			wmStructPointer = 21;
 			break;
 		}
-		DEBUG_LINE;
 		if (!ws[wmStructPointer].bActive)
 		{
 			bimg::ImageContainer* img = LoadImageFromFile(localn);
@@ -120,24 +118,19 @@ void _wtpGl()
 			ws[wmStructPointer].height = img->m_height;
 			ws[wmStructPointer].width = img->m_width;
 			ws[wmStructPointer].bActive = true;
-			DEBUG_LINE;
 			OutputDebug("\tstbi::w: %d; h: %d; channels: %d\n", ws[wmStructPointer].width, ws[wmStructPointer].height, ws[wmStructPointer].channels);
 		}
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
-		DEBUG_LINE;
 		OutputDebug("\t%u\n", texIndex);
 		TextureFormatInfo& texInfo = s_textureFormat[ws[wmStructPointer].buffer->m_format];
-		DEBUG_LINE;
 		if (bimg::isCompressed(ws[wmStructPointer].buffer->m_format))
 		{
-			DEBUG_LINE;
 			RenderCompressedTexture(ws[wmStructPointer].buffer, texInfo);
 		}
 		else
 		{
-			DEBUG_LINE;
 			RenderUncompressedTexture(ws[wmStructPointer].buffer, texInfo);
 		}
 	}

--- a/ff8_demaster/texturepatch_v2_world.cpp
+++ b/ff8_demaster/texturepatch_v2_world.cpp
@@ -129,7 +129,7 @@ int GetTextureIndex()
 		case 15: //vehicles + character
 			return -1;
 		case 28: //water textures
-			return 28;
+			return -1;
 		case 29: //tracks, bridge, vehicle
 			return 29;
 		case 20:


### PR DESCRIPTION
.gitignore added some things to prevent clion from being committed. Added .gitignore to the solution to so we can edit it inside of Visual Studio.
LoadImageFromFile made the filename variable const char* const. Since we aren’t changing the filename or what we point to in this function. This allows users to pass it anything they want. When it’s not const it prevents me from sending a const *.

DDSorPNG is a wrapper around some code that we had duplicated everywhere. This will sprintf the format with all the args and then append DDS check to see if it exists. Then do it again for PNG. Returns false if found an image. Returns true if it can’t find the image.

Removed extra \ from outpath.
Reordered some code.
Fixed spots calling sprintf for no reason. Many they looked like they were meant for OutputDebug so I updated them.
Added new line before common_load_texture it helps separate multiple texture loads in log.
Added nextFrame to battleSceneryStructure. I use this to iterate when ever the game asks for the texture again. Might not be good enough but it’s a start. PNG animates really slow this way. DDS I couldn't tell if it was slowed down. :P
Added LoadImageInto___Structure functions for world and battle. This removed some duplicated code.
Fix paletted texture loading for Field BG, Though DDS probably isn’t working there. The game seems to append .png to the file names. And the palette number makes no damn sense.

Also added /ignore to the linker for some common warnings we were getting.

I fixed the Roads on world map. We were using the incorrect index variable.

related to https://github.com/MaKiPL/FF8_demastered/issues/34