### PR TITLE
Fix crash error

### DIFF
--- a/ff8_demaster/texturepatch_v2_fieldBackground.cpp
+++ b/ff8_demaster/texturepatch_v2_fieldBackground.cpp
@@ -26,13 +26,10 @@ bool GetFieldBackgroundFilename(char* buffer, bool force_retry = false)
 		if(maplistVector.capacity() < 982)
 			maplistVector.reserve(982);
 		const char* const maplist_src = []() {
-			const char* t = (const char*)(*(DWORD*)(IMAGE_BASE + 0x189559C) + 0x118 + cached_maplist_size);
-			if (*t == '\n')
-			{
-				++t;
-				++cached_maplist_size;
-			}
-			return t;
+			const char* tmp_ptr = (const char*)(*(DWORD*)(IMAGE_BASE + 0x189559C) + 0x118 + cached_maplist_size);
+			if (*tmp_ptr == '\n')
+				(void)++tmp_ptr, ++cached_maplist_size;
+			return tmp_ptr;
 		}();
 		const std::string maplist = std::string{ maplist_src };
 		cached_maplist_size += maplist.size();

--- a/ff8_demaster/texturepatch_v2_fieldBackground.cpp
+++ b/ff8_demaster/texturepatch_v2_fieldBackground.cpp
@@ -29,7 +29,7 @@ bool GetFieldBackgroundFilename(char* buffer, bool force_retry = false)
 			const char* t = (const char*)(*(DWORD*)(IMAGE_BASE + 0x189559C) + 0x118 + cached_maplist_size);
 			if (*t == '\n')
 			{
-				t += 1;
+				++t;
 				++cached_maplist_size;
 			}
 			return t;

--- a/ff8_demaster/texturepatch_v2_fieldBackground.cpp
+++ b/ff8_demaster/texturepatch_v2_fieldBackground.cpp
@@ -17,7 +17,7 @@ bool GetFieldBackgroundFilename(char* buffer, bool force_retry = false)
 	const int fieldId = *(DWORD*)(IMAGE_BASE + 0x1782140) & 0xFFFF;
 	if (maplistVector.empty() || force_retry)
 	{
-		[[maybe_unused]] const auto oldsize = maplistVector.size();
+		const auto oldsize = maplistVector.size();
 		static size_t cached_maplist_size{};
 		if (maplistVector.capacity() < 982)
 			maplistVector.reserve(982);
@@ -37,10 +37,7 @@ bool GetFieldBackgroundFilename(char* buffer, bool force_retry = false)
 				maplistVector.emplace_back(std::move(mapname));
 			}
 		}
-		if (force_retry)
-			OutputDebug("%s::%d- Reloaded Maplist!\toldsize: %d\tsize: %d\n", __func__, __LINE__, oldsize, maplistVector.size());
-		else
-			OutputDebug("%s::%d- Loaded Maplist!\tsize: %d\n", __func__, __LINE__, maplistVector.size());
+		OutputDebug("%s::%d- %s Maplist!\toldsize: %d\tsize: %d\n", __func__, __LINE__, (force_retry ? "ReLoaded" : "Loaded"), oldsize, maplistVector.size());
 	}
 
 	if (maplistVector.size() <= static_cast<size_t>(fieldId))

--- a/ff8_demaster/texturepatch_v2_fieldBackground.cpp
+++ b/ff8_demaster/texturepatch_v2_fieldBackground.cpp
@@ -13,70 +13,56 @@ BYTE* _asm_FieldBgRetAddr3;
 /// <returns>false if no issues</returns>
 bool GetFieldBackgroundFilename(char* buffer, bool force_retry = false)
 {
-
 	static std::vector<std::string> maplistVector{};
-
 	const int fieldId = *(DWORD*)(IMAGE_BASE + 0x1782140) & 0xFFFF;
-	
-	int currentFieldId = 0;
 	if (maplistVector.empty() || force_retry)
 	{
 		[[maybe_unused]] const auto oldsize = maplistVector.size();
 		static size_t cached_maplist_size{};
-		if(maplistVector.capacity() < 982)
+		if (maplistVector.capacity() < 982)
 			maplistVector.reserve(982);
 		const char* const maplist_src = []() {
 			const char* tmp_ptr = (const char*)(*(DWORD*)(IMAGE_BASE + 0x189559C) + 0x118 + cached_maplist_size);
-			if (*tmp_ptr == '\n')
+			if (*tmp_ptr == '\n') //The \n tends to be left at the front on reloading.
 				(void)++tmp_ptr, ++cached_maplist_size;
 			return tmp_ptr;
 		}();
 		const std::string maplist = std::string{ maplist_src };
-		cached_maplist_size += maplist.size();
-		auto iss = std::istringstream(maplist, std::ios::in | std::ios::binary);
-		std::string mapname{};
-		while (std::getline(iss,mapname))
+		cached_maplist_size += maplist.size(); // remember how much of the maplist we have read.
 		{
-			maplistVector.emplace_back(std::move(mapname));
+			auto iss = std::istringstream(maplist, std::ios::in | std::ios::binary);
+			std::string mapname{};
+			while (std::getline(iss, mapname))
+			{
+				maplistVector.emplace_back(std::move(mapname));
+			}
 		}
 		if (force_retry)
-		{
 			OutputDebug("%s::%d- Reloaded Maplist!\toldsize: %d\tsize: %d\n", __func__, __LINE__, oldsize, maplistVector.size());
-		}
 		else
-		{
 			OutputDebug("%s::%d- Loaded Maplist!\tsize: %d\n", __func__, __LINE__, maplistVector.size());
-		}
 	}
 
-	
 	if (maplistVector.size() <= static_cast<size_t>(fieldId))
 	{
-		if (force_retry)
+		if (!force_retry)
+			return GetFieldBackgroundFilename(buffer, true);
+		OutputDebug("%s::%d- Invalid fieldId: %d / %d\n", __func__, __LINE__, fieldId, maplistVector.size());
 		{
-			OutputDebug("%s::%d- Invalid fieldId: %d / %d\n", __func__, __LINE__, fieldId, maplistVector.size());
 			size_t i = 0;
 			for (const auto map : maplistVector)
 			{
 				OutputDebug("\t%d - %s", i++, map.c_str());
 			}
-			return true; //fixes a crash.
 		}
-		return GetFieldBackgroundFilename(buffer, true);
+		return true; //failed to read fieldId
 	}
-	std::string mapName(maplistVector[fieldId]);
 
-	
-	std::string dirName(mapName);
-
-	
-	dirName.erase(2, dirName.length()-2); //get only two chars
-
-
-	
+	const std::string& mapName(maplistVector[fieldId]);
+	const std::string dirName(mapName.substr(0,2U)); //get only two chars
 	sprintf(buffer, "field_bg\\%s\\%s\\%s_", dirName.c_str(), mapName.c_str(), mapName.c_str());
-	OutputDebug("%s::%d- %s\n", __func__, __LINE__,buffer);
-	return false;
+	OutputDebug("%s::%d- %s\n", __func__, __LINE__, buffer);
+	return false; // no issues found.
 }
 
 DWORD fieldBackgroundRequestedTPage;
@@ -95,34 +81,34 @@ char* GetFieldBackgroundReplacementTextureName()
 	static char localn2[256]{ 0 };
 	int palette = tex_header[52];
 
-	
+
 	if (GetFieldBackgroundFilename(n))
 	{
 		n2[0] = '\0';
 		return n2;
 	}
 
-	
+
 	sprintf(localn2, "%s%u_%u", n, fieldBackgroundRequestedTPage - 16, palette);
 
-	
-	DDSorPNG(localn,256, "%stextures\\%s%u_%u", DIRECT_IO_EXPORT_DIR, n, fieldBackgroundRequestedTPage -16, palette);
+
+	DDSorPNG(localn, 256, "%stextures\\%s%u_%u", DIRECT_IO_EXPORT_DIR, n, fieldBackgroundRequestedTPage - 16, palette);
 
 	if (GetFileAttributesA(localn) == INVALID_FILE_ATTRIBUTES)
 	{
-		
+
 		OutputDebug("%s: %s, %s\n", __func__, localn, "palette not found");
 
-		
-		sprintf(n2, "%s%u",n, fieldBackgroundRequestedTPage - 16);
 
-		
+		sprintf(n2, "%s%u", n, fieldBackgroundRequestedTPage - 16);
+
+
 		OutputDebug("%s: %s\n", __func__, n2);
 		return n2;
 	}
 	else
 	{
-		
+
 		OutputDebug("%s: %s\n", __func__, localn);
 		return localn2;
 	}
@@ -132,12 +118,12 @@ __declspec(naked) void _asm_InjectFieldBackgroundModule()
 {
 	__asm
 	{
-	//save stack
+		//save stack
 		PUSH EBX
 		PUSH EDX
 
 		//get requested tPage
-		MOV EAX, dword ptr[edi+0xC]
+		MOV EAX, dword ptr[edi + 0xC]
 		MOV fieldBackgroundRequestedTPage, EAX
 
 
@@ -170,26 +156,26 @@ DWORD GetFieldBackgroundReplacementExist()
 	const size_t s = 256U;
 	char n[s]{ 0 };
 	char localn[s]{ 0 };
-	
+
 	if (GetFieldBackgroundFilename(n))
 	{
 		n[0] = '\0';
 		return 0;
 	}
 
-	
+
 	DDSorPNG(localn, s, "%stextures\\%s0", DIRECT_IO_EXPORT_DIR, n);
 
 	if (GetFileAttributesA(localn) == INVALID_FILE_ATTRIBUTES)
 	{
-		
-		OutputDebug("%s:%d: %s, %s\n", __func__,__LINE__, localn, "not found");
+
+		OutputDebug("%s:%d: %s, %s\n", __func__, __LINE__, localn, "not found");
 		return 0;
 	}
 
 	fieldReplacementFound = 1;
 
-	
+
 	OutputDebug("%s: fieldReplacementFound: %d %s\n", __func__, fieldReplacementFound, localn);
 
 	return fieldReplacementFound;
@@ -199,7 +185,7 @@ __declspec(naked) void _asm_CheckTextureReplacementExists()
 {
 	__asm
 	{
-	//save stack
+		//save stack
 		PUSH EAX
 		PUSH EBX
 		PUSH ECX
@@ -209,7 +195,7 @@ __declspec(naked) void _asm_CheckTextureReplacementExists()
 		MOV EDX, OFFSET IMAGE_BASE
 		MOV EDX, [EDX]
 		ADD EDX, 0x1782080
-		MOV [EDX], EAX //pushes GetFieldBackgroundReplacementExist DWORD bool to [EDX]
+		MOV[EDX], EAX //pushes GetFieldBackgroundReplacementExist DWORD bool to [EDX]
 
 		//restore stack
 		POP EDX
@@ -226,14 +212,14 @@ __declspec(naked) void _asm_CheckTextureReplacementExists()
 
 void ApplyFieldBackgroundPatch()
 {
-	
+
 	_asm_FieldBgRetAddr3 = InjectJMP(IMAGE_BASE + 0x1591B75, (DWORD)_asm_CheckTextureReplacementExists, 20);
 
-		//disable tpage 16&17 limit
-		modPage(IMAGE_BASE + 0x1606595, 1);
-		*(BYTE*)(IMAGE_BASE + 0x1606595) = 0xEB;
+	//disable tpage 16&17 limit
+	modPage(IMAGE_BASE + 0x1606595, 1);
+	*(BYTE*)(IMAGE_BASE + 0x1606595) = 0xEB;
 
 	//we now inject JMP when CMP fieldIfd, gover and do out stuff, then return to glSegment
-		_asm_FieldBgRetAddr2 = InjectJMP(IMAGE_BASE + 0x1606540, (DWORD)_asm_InjectFieldBackgroundModule, 42);//169-11);
+	_asm_FieldBgRetAddr2 = InjectJMP(IMAGE_BASE + 0x1606540, (DWORD)_asm_InjectFieldBackgroundModule, 42);//169-11);
 }
 #undef CRASHLOG

--- a/ff8_demaster/texturepatch_v2_fieldBackground.cpp
+++ b/ff8_demaster/texturepatch_v2_fieldBackground.cpp
@@ -45,30 +45,12 @@ bool GetFieldBackgroundFilename(char* buffer, bool force_retry = false)
 		if (force_retry)
 		{
 			OutputDebug("%s::%d- Reloaded Maplist!\toldsize: %d\tsize: %d\n", __func__, __LINE__, oldsize, maplistVector.size());
-			size_t i{};
-			for (const auto map : maplistVector)
-			{
-				OutputDebug("\t%d - %s", i++, map.c_str());
-			}
-			puts("\n");
 		}
 		else
 		{
 			OutputDebug("%s::%d- Loaded Maplist!\tsize: %d\n", __func__, __LINE__, maplistVector.size());
 		}
 	}
-	//if (force_retry)
-	//{
-	//	auto iss = std::istringstream(maplist, std::ios::in | std::ios::binary);
-	//	std::string mapname{};
-	//	auto oldsize = maplistVector.size();
-	//	for (size_t i=0; std::getline(iss, mapname);++i)
-	//	{
-	//		if(i == maplistVector.size())
-	//			maplistVector.emplace_back(std::move(mapname));
-	//	}
-	//	OutputDebug("%s::%d- Reloaded Maplist!\toldsize: %d\tsize: %d\n", __func__, __LINE__, oldsize, maplistVector.size());
-	//}
 
 	
 	if (maplistVector.size() <= static_cast<size_t>(fieldId))


### PR DESCRIPTION
* Fixes: https://github.com/MaKiPL/FF8_demastered/issues/40
  * We weren't checking for `(maplistVector.size() <= static_cast<size_t>(fieldId))`
    * This might seem backwards but basically if the statement above is true then we have to do something. If it's false continue on like normal. :D
    * The game seems stop reading the `maplist` at the `fieldId` you loaded in on. 
    * So when you goto a `fieldId` above that number it would crash.
   * The fix causes `GetFieldBackgroundFilename` to check the `maplist` again. And, append the missing names up to the new `fieldId`.
   * I changed the return value for `GetFieldBackgroundFilename` to `bool`.
     * If we return true then it failed.
     * This was my initial fix to prevent the crash from happening.
     * Now it's just extra protection.
* Removed `strtok`: Opted for `std::get_line()`.
  * We were coping the `const char[]` to a new `char[]` anyway, so now it's copied to a `std::string`.
    * This lets us use `std::istringstream` so we're reading that memory like it's a file.
    * I also store the last known size of the string. Since we're copying each line into a `std::vector<std::string>.`
      * So when we need to reread the `maplist` from the game's memory, we can skip over the part we already read.
* `maplistVector.reserve(982);`
  * This was done to reduce calls to aloc by `std::vector`
  * There are 982 field names listed in `maplist`. At least in the english one.