### PR TITLE
Tweaks to code

### DIFF
--- a/ff8_demaster/coreHeader.h
+++ b/ff8_demaster/coreHeader.h
@@ -10,6 +10,8 @@
 #include <StackWalker.h>
 #include <INIReader.h>
 #include "renderer.h"
+#include <memory>
+#include <fstream>
 
 #define EXPORT __declspec(dllexport)
 
@@ -30,7 +32,10 @@ extern const char* DIRECT_IO_EXPORT_DIR;
 extern DWORD DIRECT_IO_EXPORT_DIR_LEN;
 
 extern bx::DefaultAllocator texAllocator;
-bimg::ImageContainer* LoadImageFromFile(const char* const filename);
+
+using safe_bimg = std::unique_ptr<bimg::ImageContainer, decltype(&bimg::imageFree)>;
+safe_bimg safe_bimg_init(bimg::ImageContainer* img = nullptr);
+safe_bimg LoadImageFromFile(const char* const filename);
 
 void ApplyDirectIO();
 void ApplyUVPatch();
@@ -67,7 +72,7 @@ extern DWORD* langIdent_ESI;
 
 extern int currentStage;
 
-extern FILE* logFile;
+extern std::unique_ptr<FILE,decltype(&fclose)> logFile;
 void OutputDebug(const char* fmt, ...);
 bool DDSorPNG(char* buffer, size_t size, const char* fmt, ...);
 

--- a/ff8_demaster/iopatch.cpp
+++ b/ff8_demaster/iopatch.cpp
@@ -97,7 +97,7 @@ __declspec(naked) void directIO_fopenReroute3()
 	else
 	{
 		fd = fopen(IO_backlogFilePath, "rb");
-		fseek(fd, 0, 2); //back
+		fseek(fd, 0, SEEK_END); //back
 		loc00 = ftell(fd);
 		fclose(fd);
 	}

--- a/ff8_demaster/texturepatch_v2_battleCharacter.cpp
+++ b/ff8_demaster/texturepatch_v2_battleCharacter.cpp
@@ -16,12 +16,11 @@ void _bcpObtainTextureDatas(int aIndex)
 
 	DDSorPNG(n, 256, "%stextures\\battle.fs\\hd_new\\d%xc%03u_0", DIRECT_IO_EXPORT_DIR, (aIndex - 4097) / 100, (aIndex - 4097) % 100);
 	
-	bimg::ImageContainer* img = LoadImageFromFile(n); //chara 0
+	auto img = LoadImageFromFile(n); //chara 0
 	width_bcp = img->m_width * 2;
 	height_bcp = img->m_height * 2;
 
 	OutputDebug("_bcpObtainTextureDatas:: width=%d, height=%d, filename=%s\n", width_bcp, height_bcp, n);
-	bimg::imageFree(img);
 	return;
 }
 

--- a/ff8_demaster/texturepatch_v2_battleScenery.cpp
+++ b/ff8_demaster/texturepatch_v2_battleScenery.cpp
@@ -19,40 +19,46 @@ DWORD lastStage;
 struct battleSceneryStructure
 {
 	char localPath[256]{ 0 };
-	DWORD tpage;
-	bimg::ImageContainer* buffer;
-	int width;
-	int height;
-	int channels;
-	bool bActive;
-	int nextFrame;
+	DWORD tpage{};
+	safe_bimg buffer{ safe_bimg_init() };
+	int width{-1};
+	int height{-1};
+	int channels{-1};
+	bool bActive{false};
+	int nextFrame{0};
+	battleSceneryStructure(DWORD in_tpage)
+		: tpage{in_tpage}
+	{
+	}
 };
 
 struct battleSceneryStructure bss[] =
 {
-	{"", 16, NULL, -1,-1,-1,FALSE,0},
-	{"", 17, NULL, -1,-1,-1,FALSE,0},
-	{"", 18, NULL, -1,-1,-1,FALSE,0},
-	{"", 19, NULL, -1,-1,-1,FALSE,0},
-	{"", 20, NULL, -1,-1,-1,FALSE,0},
-	{"", 21, NULL, -1,-1,-1,FALSE,0},
-	{"", 22, NULL, -1,-1,-1,FALSE,0}
+	{16},
+	{17},
+	{18},
+	{19},
+	{20},
+	{21},
+	{22}
 };
 
 void bssInvalidateTexPath(DWORD tPage);
 void LoadImageIntoBattleSceneryStruct(const size_t index, const DWORD tPage, const char* const localn)
 {
+	if (bss[index].buffer && strcmp(bss[index].localPath, localn) == 0)
+		return;
 	int palette = tex_header[52];
 	//spamming so i put it here so it only logs when loading.
 	OutputDebug("%s::Stage: %d, Tpage: %d, Palette: %d\n", __func__, currentStage, tPage, palette);
-	bimg::ImageContainer* img = LoadImageFromFile(localn);
+	auto img = LoadImageFromFile(localn);
 	bss[index].bActive = true;
 	bss[index].width = img->m_width;
 	bss[index].height = img->m_width;
 	bss[index].channels = img->m_hasAlpha ? 4 : 3;
 	bssInvalidateTexPath(tPage);
 	strcpy(bss[index].localPath, localn);
-	bss[index].buffer = img;
+	bss[index].buffer = std::move(img);
 	bss[index].tpage = tPage;
 	OutputDebug("\t%s::Battle texture for page: %d", __func__, tPage);
 	OutputDebug("\t%s::w: %d; h: %d; channels: %d\n", __func__, bss[index].width, bss[index].height, bss[index].channels);
@@ -61,28 +67,17 @@ void _bspGl()
 {
 	DWORD tPage = gl_textures[50];
 	char localn[256]{ 0 };
-	if(DDSorPNG(localn, 256, "%stextures\\battle.fs\\hd_new\\a0stg%03d_%d_%d", DIRECT_IO_EXPORT_DIR, currentStage, tPage, bss[tPage - 16].nextFrame++))
-		if(bss[tPage - 16].nextFrame != 1 && !DDSorPNG(localn, 256, "%stextures\\battle.fs\\hd_new\\a0stg%03d_%d_%d", DIRECT_IO_EXPORT_DIR, currentStage, tPage, 0))
+	if (DDSorPNG(localn, 256, "%stextures\\battle.fs\\hd_new\\a0stg%03d_%d_%d", DIRECT_IO_EXPORT_DIR, currentStage, tPage, bss[tPage - 16].nextFrame++))
+		if (bss[tPage - 16].nextFrame != 1 && !DDSorPNG(localn, 256, "%stextures\\battle.fs\\hd_new\\a0stg%03d_%d_%d", DIRECT_IO_EXPORT_DIR, currentStage, tPage, 0))
 		{
 			//nextFrame == 1 means there is no 0 frame so we can skip the heavy DDSorPNG;
 			bss[tPage - 16].nextFrame = 1; //current nextFrame didn't exist so we went back to 0 and change nextFrame to 1.
 		}
 		else
 			DDSorPNG(localn, 256, "%stextures\\battle.fs\\hd_new\\a0stg%03d_%d", DIRECT_IO_EXPORT_DIR, currentStage, tPage);
-	if (bss[tPage - 16].buffer == NULL)
-	{
-		LoadImageIntoBattleSceneryStruct(tPage - 16, tPage, localn);		
-	}
-	else
-	{
-		if (strcmp(bss[tPage - 16].localPath, localn) != 0)
-		{
-			bimg::imageFree(bss[tPage - 16].buffer); //let's release memory from unused texture
-			LoadImageIntoBattleSceneryStruct(tPage - 16, tPage, localn);
-		}
-		
-	}
-	RenderTexture(bss[tPage - 16].buffer);
+
+	LoadImageIntoBattleSceneryStruct(tPage - 16, tPage, localn);
+	RenderTexture(bss[tPage - 16].buffer.get());
 	return;
 }
 
@@ -104,10 +99,10 @@ DWORD _bspCheck()
 		return 0;
 	if (tPage > 21)
 		return 0;
-	char localn[256]{ 0 };	
+	char localn[256]{ 0 };
 	if (DDSorPNG(localn, 256, "%stextures\\battle.fs\\hd_new\\a0stg%03d_%d", DIRECT_IO_EXPORT_DIR, currentStage, tPage))
 	{
-		OutputDebug("%s FAILED ON TEXTURE!; Expected: a0stg%03d_%d.(dds|png)\n", __func__ ,currentStage, tPage);
+		OutputDebug("%s FAILED ON TEXTURE!; Expected: a0stg%03d_%d.(dds|png)\n", __func__, currentStage, tPage);
 		return 0;
 	}
 	OutputDebug("%s: Happy at a0stg%03d_%d.(dds|png)\n", __func__, currentStage, tPage);
@@ -157,12 +152,12 @@ __declspec(naked) void _bsp()
 			_out :
 		JMP _bspBackAdd1
 
-			_wtpOk:
-			MOV EAX, OFFSET IMAGE_BASE
+			_wtpOk :
+		MOV EAX, OFFSET IMAGE_BASE
 			MOV EAX, [EAX]
 			ADD EAX, 0x166B2A8
-			PUSH DWORD PTR[EBP+0x10]
-			CALL [EAX]
+			PUSH DWORD PTR[EBP + 0x10]
+			CALL[EAX]
 			//CALL DWORD PTR DS:0x1166B2A8
 			MOV bAlreadyFreed, 1
 			CALL _wtpGl

--- a/ff8_demaster/texturepatch_v2_fieldChara.cpp
+++ b/ff8_demaster/texturepatch_v2_fieldChara.cpp
@@ -47,7 +47,7 @@ void _fcpObtainTextureDatas(int bIndex, int aIndex)
 	strcpy(texPath, testPath); //establish path
 
 
-	bimg::ImageContainer* img = LoadImageFromFile(texPath);
+	auto img = LoadImageFromFile(texPath);
 
 	//the most important is height here
 	height_fcp = img->m_height * 2;
@@ -55,7 +55,6 @@ void _fcpObtainTextureDatas(int bIndex, int aIndex)
 
 
 	OutputDebug("_fcpObtainTextureDatas:: width=%d, height=%d, width_fcp=%d, height_fcp=%d, filename=%s\n", img->m_width, img->m_height, width_fcp, height_fcp, texPath);
-	bimg::imageFree(img);
 	return;
 }
 

--- a/ff8_demaster/texturepatch_v2_world.cpp
+++ b/ff8_demaster/texturepatch_v2_world.cpp
@@ -15,7 +15,7 @@ struct worldTextureStructure
 	int height{ -1 };
 	int channels{ -1 };
 	bool bActive{ false };
-	worldTextureStructure(DWORD in_tpage)
+	worldTextureStructure(DWORD in_tpage) noexcept
 		: tpage{ in_tpage }
 	{
 
@@ -45,14 +45,14 @@ worldTextureStructure ws[] =
 	{18},
 	{19},
 	{20},
-	{21}, //TRAIN TRACKS
-	{22}, //CLOUDS
-	{23}, //MAP
-	{24}, //moon texture + fx
-	{25}, //WATER
-	{26}, //characters
-	{27}, //16 ??? textype=18
-	{28},	// 0: textype=0
+	{21},   // TRAIN TRACKS
+	{22},   // CLOUDS
+	{23},   // MAP
+	{24},   // moon texture + fx
+	{25},   // WATER
+	{26},   // characters
+	{27},   // 16: textype=18 ???
+	{28},	// 0:  textype=0
 	{29},	// 13: textype=0 full screen wm, sm wm, clouds
 	{30},	// 15: textype=0 sm wm
 	{31},	// 20: textype=0

--- a/ff8_demaster/texturepatch_v2_world.cpp
+++ b/ff8_demaster/texturepatch_v2_world.cpp
@@ -10,7 +10,7 @@ struct worldTextureStructure
 {
 	char localPath[256]{ 0 };
 	DWORD tpage{};
-	safe_bimg&& buffer{ safe_bimg_init() };
+	safe_bimg buffer{ safe_bimg_init() };
 	int width{ -1 };
 	int height{ -1 };
 	int channels{ -1 };

--- a/ff8_demaster/vendor/include/INIReader.h
+++ b/ff8_demaster/vendor/include/INIReader.h
@@ -354,7 +354,7 @@ public:
     bool GetBoolean(std::string section, std::string name, bool default_value) const;
 
 protected:
-    int _error{};
+    int _error;
     std::map<std::string, std::string> _values;
     std::set<std::string> _sections;
     static std::string MakeKey(std::string section, std::string name);

--- a/ff8_demaster/vendor/include/INIReader.h
+++ b/ff8_demaster/vendor/include/INIReader.h
@@ -354,7 +354,7 @@ public:
     bool GetBoolean(std::string section, std::string name, bool default_value) const;
 
 protected:
-    int _error;
+    int _error{};
     std::map<std::string, std::string> _values;
     std::set<std::string> _sections;
     static std::string MakeKey(std::string section, std::string name);


### PR DESCRIPTION
Minor changes. Using unique pointer and extending the texture cache in battle scenery to use a vector. This was done to cache stage animations.

* `std::unique_ptr`
  * This lets us tie deleters to the pointers. [RAII](https://en.cppreference.com/w/cpp/language/raii) will auto delete the pointer for us.
    * `using safe_bimg = std::unique_ptr<bimg::ImageContainer, decltype(&bimg::imageFree)>`
      * texture is automatically freed
    * `std::unique_ptr<FILE,decltype(&fclose)>`
      * file pointer automatically closes.
      * Though some cases might it might be better to use `std::fstream`.
    * `std::make_unique<char[]>(static_cast<size_t>(filesize))`
      *  dynamic char array is automatically freed.
* `std::fstream(filename, std::ios::in | std::ios::binary)`
  * There was a section that loads the entire image file into a char[], I rewrote it to use fstream. fstream will auto close itself.
* `struct battleSceneryStructure` and `struct worldTextureStructure`
  * added a constructor because all the default values were the same except for `tpage`.
* `struct battleSceneryStructure`
  * Moved `localPath` and `buffer` into a new `struct battleSceneryPathandTexture`
    * I switched to `std::string` for `localPath`, was just easier to work with the changes I was making.
  * and made a `std::vector<battleSceneryPathandTexture>` to store the textures and their paths for each frame of animation.
  * added member functions to fetch `current()` frame and `update(battleSceneryPathandTexture&& new_img)` a frame.
* `void LoadImageIntoBattleSceneryStruct`
  * check if `bss[index].current().localPath == localn` 
    * Problem when animations aren't detected it would keep reloading the current texture over and over. This basically froze the game if the texture was a png.