### PR TITLE
Fixes to battle stage cache from bugs in previous pull request.

### DIFF
--- a/ff8_demaster/texturepatch_v2_battleCharacter.cpp
+++ b/ff8_demaster/texturepatch_v2_battleCharacter.cpp
@@ -16,7 +16,9 @@ void _bcpObtainTextureDatas(int aIndex)
 
 	DDSorPNG(n, 256, "%stextures\\battle.fs\\hd_new\\d%xc%03u_0", DIRECT_IO_EXPORT_DIR, (aIndex - 4097) / 100, (aIndex - 4097) % 100);
 	
-	auto img = LoadImageFromFile(n); //chara 0
+	safe_bimg img = LoadImageFromFile(n); //chara 0
+	if (!img)
+		return;
 	width_bcp = img->m_width * 2;
 	height_bcp = img->m_height * 2;
 

--- a/ff8_demaster/texturepatch_v2_fieldChara.cpp
+++ b/ff8_demaster/texturepatch_v2_fieldChara.cpp
@@ -47,9 +47,11 @@ void _fcpObtainTextureDatas(int bIndex, int aIndex)
 	strcpy(texPath, testPath); //establish path
 
 
-	auto img = LoadImageFromFile(texPath);
+	safe_bimg img = LoadImageFromFile(texPath);
 
 	//the most important is height here
+	if (!img)
+		return;
 	height_fcp = img->m_height * 2;
 	
 

--- a/ff8_demaster/texturepatch_v2_world.cpp
+++ b/ff8_demaster/texturepatch_v2_world.cpp
@@ -65,7 +65,7 @@ int GetTextureIndex();
 
 //you can't just create new folder because >WEEP< - too lazy to find the cause
 DWORD lastKnownTextureId{ 0 };
-void LoadImageIntoWorldStruct(size_t texIndex, const char* const localn, int tPage, int palette)
+bool LoadImageIntoWorldStruct(size_t texIndex, const char* const localn, int tPage, int palette)
 {
 	//If you want to be able to swap out a texture at a given index you could set bActive to false and it would force load it.
 	if (ws[texIndex].bActive && ws[texIndex].buffer)//texture loaded skip
@@ -74,9 +74,11 @@ void LoadImageIntoWorldStruct(size_t texIndex, const char* const localn, int tPa
 		{
 			OutputDebug("%s::%d::WARNING attempt to load texture with new name:\n\t%s\n\t!=\n\t%s\n", __func__,__LINE__, localn, ws[texIndex].localPath);
 		}
-		return;
+		return true;
 	}
-	auto img = LoadImageFromFile(localn);
+	safe_bimg img = LoadImageFromFile(localn);
+	if (!img)
+		return false;
 	ws[texIndex].width = img->m_width;
 	ws[texIndex].height = img->m_height;
 	ws[texIndex].channels = img->m_hasAlpha ? 4 : 3;
@@ -86,7 +88,7 @@ void LoadImageIntoWorldStruct(size_t texIndex, const char* const localn, int tPa
 
 	OutputDebug("\t%s::%d::localEAX: %d, Tpage: %d, Palette: %d, TexIndex: %d\n", __func__, __LINE__, *(DWORD*)(IMAGE_BASE + 0x1780f88), tPage, palette, texIndex);
 	OutputDebug("\t%s::%d::w: %d; h: %d; channels: %d\n", __func__, __LINE__, ws[texIndex].width, ws[texIndex].height, ws[texIndex].channels);
-
+	return true;
 }
 void _wtpGl()
 {
@@ -152,10 +154,12 @@ void _wtpGl()
 			wmStructPointer = 21;
 			break;
 		}
-		LoadImageIntoWorldStruct(wmStructPointer, localn, tPage, palette);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-		RenderTexture(ws[wmStructPointer].buffer.get());
+		if (LoadImageIntoWorldStruct(wmStructPointer, localn, tPage, palette))
+		{
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+			RenderTexture(ws[wmStructPointer].buffer.get());
+		}
 	}
 	else if (textureType == 0)
 	{
@@ -190,10 +194,12 @@ void _wtpGl()
 			wmStructPointer = 34;
 			break;
 		}
-		LoadImageIntoWorldStruct(wmStructPointer, localn, tPage, palette);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-		RenderTexture(ws[wmStructPointer].buffer.get());
+		if (LoadImageIntoWorldStruct(wmStructPointer, localn, tPage, palette))
+		{
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+			RenderTexture(ws[wmStructPointer].buffer.get());
+		}
 	}
 	return;
 }


### PR DESCRIPTION
I found and fixed some issues from https://github.com/MaKiPL/FF8_demastered/pull/42 that I missed. Seems to work as expected now.
1) It was incrementing the frame counter and never setting it back to 1. 
  * So i would load a lot more copies of images than needed.
2) Crash occurred when failing to load a texture because there were too many textures loaded.
  * So instead crashing you may see a black texture in the case of a failure to load.
  * It should be less much likely to happen now.

Though this is something to be concerned with if you go overboard on your animations by adding too many frames you could hit the limit of the computer. And start seeing black textures. Though if we used more dds over png we'd have more headroom. 

The png is surprisingly usable with animations now because of the fixes to the cache!